### PR TITLE
Fixed issue with SetUserOwner on MacOSX 

### DIFF
--- a/internal/extract/tree.go
+++ b/internal/extract/tree.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/lambdajack/sequentially-generate-planet-mbtiles/internal/docker"
+	"github.com/lambdajack/sequentially-generate-planet-mbtiles/internal/system"
 )
 
 func TreeSlicer(src, dstDir, workingDir string, targetSize uint64, gdal, osmium *docker.Container, elg, plg, rlg *log.Logger) {
@@ -112,6 +113,8 @@ func slice(src, dst, bb string, osmium *docker.Container, elg, plg, rlg *log.Log
 		elg.Fatalf("extract.go | Slicer | Failed to create temp file: %v", err)
 	}
 	defer f.Close()
+
+	system.SetUserOwner(f.Name())
 
 	rlg.Printf("slicing %s >>> %s (%s)", filepath.Base(src), filepath.Base(f.Name()), bb)
 	lp, err := Extract(src, f.Name(), bb, osmium)

--- a/internal/system/system.go
+++ b/internal/system/system.go
@@ -16,7 +16,7 @@ func SetUserOwner(path string) error {
 		return err
 	}
 
-	if u.Name == "root" && runtime.GOOS == "linux" {
+	if u.Username == "root" && (runtime.GOOS == "linux" || runtime.GOOS == "darwin") {
 		u := os.Getenv("SUDO_UID")
 		if u == "" {
 			return err


### PR DESCRIPTION
On MacOSX (tested on Sonoma 14.0) when running with sudo files get wrong (root) permissions so SetUserOwner needs to be done on darwin also.

Also  the temp file created when extracting/slicing needs to have permissions changed to avoid permission denied error.
